### PR TITLE
 #159655616 Disable link for deleted books in user history.

### DIFF
--- a/src/components/BorrowHistory.js
+++ b/src/components/BorrowHistory.js
@@ -117,11 +117,15 @@ class BorrowHistory extends Component {
                         <td>{history.Author}</td>
                         <td>{history.time_borrowed}</td>
                         <td>{history.return_date}</td>
-                        <td>
-                          <Link to={`books/${history.book_id}`}>
-                            {history.returned ? 'Returned' : 'Not Returned'}
-                          </Link>
-                        </td>
+                        {!history.deleted ? (
+                          <td>
+                            <Link to={`books/${history.book_id}`}>
+                              {history.returned ? 'Returned' : 'Not Returned'}
+                            </Link>
+                          </td>
+                        ) : (
+                          <td>No longer available</td>
+                        )}
                       </tr>
                     ))}
                   </tbody>


### PR DESCRIPTION
#### This pull request accomplishes the following:
- Disable status button on deleted book in the borrowing history page.

 #### Snapshot
![image](https://user-images.githubusercontent.com/22454909/43903522-4f62e3a8-9bf5-11e8-8060-cf6431bb1d12.png)
